### PR TITLE
fix: 修复隔离会话（unique_session）开启时会话级 ban/pass 失效的问题

### DIFF
--- a/event_utils.py
+++ b/event_utils.py
@@ -1,5 +1,6 @@
 from astrbot.api.event import AstrMessageEvent
 import astrbot.api.message_components as Comp
+from astrbot.api.star import Context
 from .user_manager import (
     UserDataModel,
     UserDataList,
@@ -10,17 +11,6 @@ from .user_manager import (
 )
 from .datafile_manager import DatafileManager
 from .exceptions import AtUserCountError
-
-
-def get_real_umo(event: AstrMessageEvent) -> str:
-    """
-    获取真实的会话 UMO，绕过隔离会话（unique_session）对 session_id 的改写。
-    使用 message_obj.session_id，该值由平台适配器设置，不受 unique_session 影响。
-    """
-    original_session_id = event.message_obj.session_id
-    platform_id = event.get_platform_id()
-    msg_type = event.get_message_type().value
-    return f"{platform_id}:{msg_type}:{original_session_id}"
 
 
 class EventUtils:
@@ -49,7 +39,7 @@ class EventUtils:
         return at_users[0] if at_users else None
 
     @staticmethod
-    def is_banned(enable: bool, data_manager: DatafileManager, event: AstrMessageEvent):
+    def is_banned(enable: bool, data_manager: DatafileManager, context: Context, event: AstrMessageEvent):
         """
         判断用户是否被禁用，以及其理由
         """
@@ -68,7 +58,7 @@ class EventUtils:
             )
 
         # 获取UMO与UID
-        umo = get_real_umo(event)
+        umo = EventUtils.get_event_umo(context, event)
         uid = event.get_sender_id()
 
         # pass
@@ -100,3 +90,15 @@ class EventUtils:
         if banumo_data:
             return (True, banumo_data.reason)
         return (False, None)
+
+    @staticmethod
+    def get_event_umo(context: Context, event: AstrMessageEvent):
+        """
+        获取 umo 信息 （当 unique_session 为 True 时，仍返回 platform_id:message_type:group_id 以便处理）
+        """
+        if (
+            context.get_config()["platform_settings"]["unique_session"]
+            and event.get_group_id()
+        ):
+            return f"{event.session.platform_id}:{event.session.message_type.value}:{event.get_group_id()}"
+        return event.unified_msg_origin

--- a/event_utils.py
+++ b/event_utils.py
@@ -12,6 +12,17 @@ from .datafile_manager import DatafileManager
 from .exceptions import AtUserCountError
 
 
+def get_real_umo(event: AstrMessageEvent) -> str:
+    """
+    获取真实的会话 UMO，绕过隔离会话（unique_session）对 session_id 的改写。
+    使用 message_obj.session_id，该值由平台适配器设置，不受 unique_session 影响。
+    """
+    original_session_id = event.message_obj.session_id
+    platform_id = event.get_platform_id()
+    msg_type = event.get_message_type().value
+    return f"{platform_id}:{msg_type}:{original_session_id}"
+
+
 class EventUtils:
     """
     事件工具类，包含处理事件的静态方法
@@ -57,7 +68,7 @@ class EventUtils:
             )
 
         # 获取UMO与UID
-        umo = event.unified_msg_origin
+        umo = get_real_umo(event)
         uid = event.get_sender_id()
 
         # pass

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from .user_manager import (
     ModelListRegistry,
     MODEL_LIST_REGISTRY,
 )
-from .event_utils import EventUtils
+from .event_utils import EventUtils, get_real_umo
 from .exceptions import *
 
 
@@ -63,7 +63,7 @@ class ReNeBan(Star):
             )
         else:
             # 获取UMO
-            umo = event.unified_msg_origin
+            umo = get_real_umo(event)
             data: dict[str, dict[str, UserDataList] | BaseModelList] = (
                 self.data_manager.get_data()
             )
@@ -253,8 +253,7 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("ban"))
             return
         if umo == None:
-            # 若umo不存在，则使用event.unified_msg_origin（当前群）
-            umo = event.unified_msg_origin
+            umo = get_real_umo(event)
         reason = strings.noreason_to_none(reason)
         try:
             ban_uid: str
@@ -407,8 +406,7 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("pass"))
             return
         if umo == None:
-            # 若umo不存在，则使用event.unified_msg_origin（当前群）
-            umo = event.unified_msg_origin
+            umo = get_real_umo(event)
         reason = strings.noreason_to_none(reason)
         try:
             pass_uid: str
@@ -560,8 +558,7 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("dec-pass"))
             return
         if umo == None:
-            # 若umo不存在，则使用event.unified_msg_origin（当前群）
-            umo = event.unified_msg_origin
+            umo = get_real_umo(event)
         reason = strings.noreason_to_none(reason)
         try:
             pass_uid: str
@@ -690,8 +687,7 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("dec-ban"))
             return
         if umo == None:
-            # 若umo不存在，则使用event.unified_msg_origin（当前群）
-            umo = event.unified_msg_origin
+            umo = get_real_umo(event)
         reason = strings.noreason_to_none(reason)
         try:
             ban_uid: str

--- a/main.py
+++ b/main.py
@@ -15,7 +15,7 @@ from .user_manager import (
     ModelListRegistry,
     MODEL_LIST_REGISTRY,
 )
-from .event_utils import EventUtils, get_real_umo
+from .event_utils import EventUtils
 from .exceptions import *
 
 
@@ -63,7 +63,7 @@ class ReNeBan(Star):
             )
         else:
             # 获取UMO
-            umo = get_real_umo(event)
+            umo = EventUtils.get_event_umo(self.context, event)
             data: dict[str, dict[str, UserDataList] | BaseModelList] = (
                 self.data_manager.get_data()
             )
@@ -208,7 +208,7 @@ class ReNeBan(Star):
         self.enable = True
         yield event.plain_result(strings.messages["ban_enabled"])
         logger.warning(
-            f"已临时启用禁用功能(in {event.unified_msg_origin} - {event.get_sender_name()}({event.get_sender_id()}))"
+            f"已临时启用禁用功能(in {EventUtils.get_event_umo(self.context, event)} - {event.get_sender_name()}({event.get_sender_id()}))"
         )
 
     @filter.permission_type(filter.PermissionType.ADMIN)
@@ -220,7 +220,7 @@ class ReNeBan(Star):
         self.enable = False
         yield event.plain_result(strings.messages["ban_disabled"])
         logger.warning(
-            f"已临时禁用禁用功能(in {event.unified_msg_origin} - {event.get_sender_name()}({event.get_sender_id()}))"
+            f"已临时禁用禁用功能(in {EventUtils.get_event_umo(self.context, event)} - {event.get_sender_name()}({event.get_sender_id()}))"
         )
 
     @filter.command("ban-help")
@@ -253,7 +253,8 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("ban"))
             return
         if umo == None:
-            umo = get_real_umo(event)
+            # 若umo不存在，则使用EventUtils.get_event_umo(self.context, event)（当前群）
+            umo = EventUtils.get_event_umo(self.context, event)
         reason = strings.noreason_to_none(reason)
         try:
             ban_uid: str
@@ -406,7 +407,8 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("pass"))
             return
         if umo == None:
-            umo = get_real_umo(event)
+            # 若umo不存在，则使用EventUtils.get_event_umo(self.context, event)（当前群）
+            umo = EventUtils.get_event_umo(self.context, event)
         reason = strings.noreason_to_none(reason)
         try:
             pass_uid: str
@@ -558,7 +560,8 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("dec-pass"))
             return
         if umo == None:
-            umo = get_real_umo(event)
+            # 若umo不存在，则使用EventUtils.get_event_umo(self.context, event)（当前群）
+            umo = EventUtils.get_event_umo(self.context, event)
         reason = strings.noreason_to_none(reason)
         try:
             pass_uid: str
@@ -687,7 +690,8 @@ class ReNeBan(Star):
             yield event.plain_result(strings.command_error("dec-ban"))
             return
         if umo == None:
-            umo = get_real_umo(event)
+            # 若umo不存在，则使用EventUtils.get_event_umo(self.context, event)（当前群）
+            umo = EventUtils.get_event_umo(self.context, event)
         reason = strings.noreason_to_none(reason)
         try:
             ban_uid: str
@@ -841,7 +845,7 @@ class ReNeBan(Star):
         全局事件过滤器：
         如果禁用功能启用且发送者被禁用，则停止事件传播，机器人不再响应该用户的消息。
         """
-        if EventUtils.is_banned(self.enable, self.data_manager, event)[0]:
+        if EventUtils.is_banned(self.enable, self.data_manager, self.context, event)[0]:
             event.stop_event()
 
     async def terminate(self):


### PR DESCRIPTION
fix #18

新增 `get_real_umo()`（`event_utils.py`），绕开 unique_session 对`session_id` 的改写，直接使用平台适配器在解析消息阶段就已设置好的`event.message_obj.session_id`（不受 unique_session 影响），手动还原真实 UMO：

将所有原先使用 `event.unified_msg_origin` 作为默认会话 key 的位置（`is_banned`、`/ban`、`/pass`、`/dec-ban`、`/dec-pass`、`/banlist`）统一替换为 `get_real_umo(event)`。

## Summary by Sourcery

Bug Fixes:
- 修复了当 `unique_session` 重写 `session_id` 时，会话级别的 ban/pass 状态被忽略的问题。现在通过基于原始消息的会话标识符而不是 `unified_msg_origin` 来解析 UMO。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix session-level ban/pass state being ignored when unique_session rewrites session_id by basing UMO resolution on the original message session identifier instead of unified_msg_origin.

</details>